### PR TITLE
Improve search UI with request/response panels

### DIFF
--- a/packages/frontend/src/components/results/RequestViewer.vue
+++ b/packages/frontend/src/components/results/RequestViewer.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { ref, watch, nextTick } from 'vue';
+import type { GrepMatch } from 'shared';
+
+const props = defineProps<{ match: GrepMatch | null; pattern: string }>();
+const searchTerm = ref(props.pattern);
+const preRef = ref<HTMLElement | null>(null);
+
+watch(
+  () => props.pattern,
+  (v) => {
+    if (!searchTerm.value) searchTerm.value = v;
+  }
+);
+
+watch(
+  () => props.match,
+  async () => {
+    await nextTick();
+    if (preRef.value) {
+      const mark = preRef.value.querySelector('mark');
+      if (mark) mark.scrollIntoView();
+    }
+  }
+);
+
+const escapeHtml = (str: string) =>
+  str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const highlight = (content: string) => {
+  if (!content) return '';
+  if (!searchTerm.value) return escapeHtml(content);
+  const regex = new RegExp(searchTerm.value, 'gi');
+  return escapeHtml(content).replace(regex, (m) => `<mark class="bg-yellow-300 text-black">${escapeHtml(m)}</mark>`);
+};
+</script>
+<template>
+  <div class="flex flex-col h-full border border-gray-700">
+    <div class="p-1 border-b border-gray-700">
+      <input v-model="searchTerm" class="w-full text-xs p-1" placeholder="Search..." />
+    </div>
+    <pre ref="preRef" class="overflow-auto flex-1 text-xs font-mono p-2" v-html="match ? highlight(match.request) : ''"></pre>
+  </div>
+</template>

--- a/packages/frontend/src/components/results/ResponseViewer.vue
+++ b/packages/frontend/src/components/results/ResponseViewer.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { ref, watch, nextTick } from 'vue';
+import type { GrepMatch } from 'shared';
+
+const props = defineProps<{ match: GrepMatch | null; pattern: string }>();
+const searchTerm = ref(props.pattern);
+const preRef = ref<HTMLElement | null>(null);
+
+watch(
+  () => props.pattern,
+  (v) => {
+    if (!searchTerm.value) searchTerm.value = v;
+  }
+);
+
+watch(
+  () => props.match,
+  async () => {
+    await nextTick();
+    if (preRef.value) {
+      const mark = preRef.value.querySelector('mark');
+      if (mark) mark.scrollIntoView();
+    }
+  }
+);
+
+const escapeHtml = (str: string) =>
+  str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+const highlight = (content: string) => {
+  if (!content) return '';
+  if (!searchTerm.value) return escapeHtml(content);
+  const regex = new RegExp(searchTerm.value, 'gi');
+  return escapeHtml(content).replace(regex, (m) => `<mark class="bg-yellow-300 text-black">${escapeHtml(m)}</mark>`);
+};
+</script>
+<template>
+  <div class="flex flex-col h-full border border-gray-700">
+    <div class="p-1 border-b border-gray-700">
+      <input v-model="searchTerm" class="w-full text-xs p-1" placeholder="Search..." />
+    </div>
+    <pre ref="preRef" class="overflow-auto flex-1 text-xs font-mono p-2" v-html="match && match.response ? highlight(match.response) : ''"></pre>
+  </div>
+</template>

--- a/packages/frontend/src/components/results/index.ts
+++ b/packages/frontend/src/components/results/index.ts
@@ -1,2 +1,1 @@
 export { default as ResultsContainer } from "./Container.vue";
-export { default as MatchItem } from "./MatchItem.vue";

--- a/packages/frontend/src/stores/grepStore.ts
+++ b/packages/frontend/src/stores/grepStore.ts
@@ -34,6 +34,11 @@ export const useGrepStore = defineStore("grep", () => {
     cancelled: false,
   });
 
+  const selectedMatch = ref<GrepMatch | null>(null);
+  const selectMatch = (match: GrepMatch) => {
+    selectedMatch.value = match;
+  };
+
   const searchGrepRequests = async () => {
     if (!pattern.value.trim()) {
       sdk.window.showToast("Please enter a search pattern", {
@@ -123,6 +128,8 @@ export const useGrepStore = defineStore("grep", () => {
     options,
     status,
     results,
+    selectedMatch,
+    selectMatch,
     searchGrepRequests,
   };
 });

--- a/packages/frontend/src/utils/http.ts
+++ b/packages/frontend/src/utils/http.ts
@@ -1,0 +1,16 @@
+export const extractHost = (raw: string): string => {
+  const match = raw.match(/\nHost:\s*(.*)/i);
+  return match ? match[1].trim() : "";
+};
+
+export const extractStatusCode = (raw: string | undefined): number | null => {
+  if (!raw) return null;
+  const first = raw.split(/\r?\n/)[0];
+  const m = first.match(/\b(\d{3})\b/);
+  return m ? parseInt(m[1], 10) : null;
+};
+
+export const extractDate = (raw: string): string | null => {
+  const match = raw.match(/\nDate:\s*(.*)/i);
+  return match ? match[1].trim() : null;
+};


### PR DESCRIPTION
## Summary
- add selection state to grep store
- parse HTTP metadata helpers
- build new RequestViewer/ResponseViewer components with search support
- redesign results page using splitter panels and virtual table
- remove unused MatchItem export

## Testing
- `pnpm -r typecheck` *(fails: Cannot find type definition file for '@caido/sdk-backend')*

------
https://chatgpt.com/codex/tasks/task_e_68665b2b97e483318c47c540f7f8622c