### PR TITLE
Enhance Data Grep match viewers

### DIFF
--- a/packages/frontend/src/components/results/RequestViewer.vue
+++ b/packages/frontend/src/components/results/RequestViewer.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import { ref, watch, nextTick } from 'vue';
+import { ref, watch, nextTick, computed, onMounted } from 'vue';
 import type { GrepMatch } from 'shared';
 
 const props = defineProps<{ match: GrepMatch | null; pattern: string }>();
 const searchTerm = ref(props.pattern);
 const preRef = ref<HTMLElement | null>(null);
+const matches = ref<HTMLElement[]>([]);
+const currentIndex = ref(0);
+let currentLineEl: HTMLElement | null = null;
 
 watch(
   () => props.pattern,
@@ -17,10 +20,7 @@ watch(
   () => props.match,
   async () => {
     await nextTick();
-    if (preRef.value) {
-      const mark = preRef.value.querySelector('mark');
-      if (mark) mark.scrollIntoView();
-    }
+    updateMatches();
   }
 );
 
@@ -33,12 +33,66 @@ const highlight = (content: string) => {
   const regex = new RegExp(searchTerm.value, 'gi');
   return escapeHtml(content).replace(regex, (m) => `<mark class="bg-yellow-300 text-black">${escapeHtml(m)}</mark>`);
 };
+
+const highlightedLines = computed(() => {
+  const content = props.match ? props.match.request : '';
+  return highlight(content).split('\n');
+});
+
+const updateMatches = async () => {
+  await nextTick();
+  if (preRef.value) {
+    matches.value = Array.from(preRef.value.querySelectorAll('mark')) as HTMLElement[];
+    currentIndex.value = 0;
+    scrollToCurrent(false);
+  }
+};
+
+const scrollToCurrent = (smooth = true) => {
+  const el = matches.value[currentIndex.value];
+  if (!el) return;
+  const lineEl = el.closest('.code-line') as HTMLElement | null;
+  if (lineEl) {
+    if (currentLineEl) currentLineEl.classList.remove('bg-yellow-100');
+    currentLineEl = lineEl;
+    currentLineEl.classList.add('bg-yellow-100');
+  }
+  el.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto', block: 'center' });
+};
+
+const nextMatch = () => {
+  if (!matches.value.length) return;
+  currentIndex.value = (currentIndex.value + 1) % matches.value.length;
+  scrollToCurrent();
+};
+
+const prevMatch = () => {
+  if (!matches.value.length) return;
+  currentIndex.value = (currentIndex.value - 1 + matches.value.length) % matches.value.length;
+  scrollToCurrent();
+};
+
+watch(searchTerm, updateMatches);
+onMounted(updateMatches);
 </script>
 <template>
-  <div class="flex flex-col h-full border border-gray-700">
-    <div class="p-1 border-b border-gray-700">
-      <input v-model="searchTerm" class="w-full text-xs p-1" placeholder="Search..." />
+  <div class="flex flex-col h-full border border-gray-700 overflow-hidden">
+    <div ref="preRef" class="flex-1 overflow-auto text-xs font-mono p-2">
+      <div v-for="(line, i) in highlightedLines" :key="i" class="flex code-line">
+        <div class="w-10 pr-2 select-none text-right text-gray-500">{{ i + 1 }}</div>
+        <div class="whitespace-pre-wrap flex-1" v-html="line"></div>
+      </div>
     </div>
-    <pre ref="preRef" class="overflow-auto flex-1 text-xs font-mono p-2" v-html="match ? highlight(match.request) : ''"></pre>
+    <div class="p-1 border-t border-gray-700 flex items-center gap-1 text-xs">
+      <input v-model="searchTerm" class="p-1 flex-1" placeholder="Search..." />
+      <button class="p-1 border border-gray-700" @click="prevMatch">&lt;</button>
+      <button class="p-1 border border-gray-700" @click="nextMatch">&gt;</button>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.code-line {
+  display: flex;
+}
+</style>

--- a/packages/frontend/src/components/results/ResponseViewer.vue
+++ b/packages/frontend/src/components/results/ResponseViewer.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
-import { ref, watch, nextTick } from 'vue';
+import { ref, watch, nextTick, computed, onMounted } from 'vue';
 import type { GrepMatch } from 'shared';
 
 const props = defineProps<{ match: GrepMatch | null; pattern: string }>();
 const searchTerm = ref(props.pattern);
 const preRef = ref<HTMLElement | null>(null);
+const matches = ref<HTMLElement[]>([]);
+const currentIndex = ref(0);
+let currentLineEl: HTMLElement | null = null;
 
 watch(
   () => props.pattern,
@@ -17,10 +20,7 @@ watch(
   () => props.match,
   async () => {
     await nextTick();
-    if (preRef.value) {
-      const mark = preRef.value.querySelector('mark');
-      if (mark) mark.scrollIntoView();
-    }
+    updateMatches();
   }
 );
 
@@ -33,12 +33,66 @@ const highlight = (content: string) => {
   const regex = new RegExp(searchTerm.value, 'gi');
   return escapeHtml(content).replace(regex, (m) => `<mark class="bg-yellow-300 text-black">${escapeHtml(m)}</mark>`);
 };
+
+const highlightedLines = computed(() => {
+  const content = props.match?.response || '';
+  return highlight(content).split('\n');
+});
+
+const updateMatches = async () => {
+  await nextTick();
+  if (preRef.value) {
+    matches.value = Array.from(preRef.value.querySelectorAll('mark')) as HTMLElement[];
+    currentIndex.value = 0;
+    scrollToCurrent(false);
+  }
+};
+
+const scrollToCurrent = (smooth = true) => {
+  const el = matches.value[currentIndex.value];
+  if (!el) return;
+  const lineEl = el.closest('.code-line') as HTMLElement | null;
+  if (lineEl) {
+    if (currentLineEl) currentLineEl.classList.remove('bg-yellow-100');
+    currentLineEl = lineEl;
+    currentLineEl.classList.add('bg-yellow-100');
+  }
+  el.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto', block: 'center' });
+};
+
+const nextMatch = () => {
+  if (!matches.value.length) return;
+  currentIndex.value = (currentIndex.value + 1) % matches.value.length;
+  scrollToCurrent();
+};
+
+const prevMatch = () => {
+  if (!matches.value.length) return;
+  currentIndex.value = (currentIndex.value - 1 + matches.value.length) % matches.value.length;
+  scrollToCurrent();
+};
+
+watch(searchTerm, updateMatches);
+onMounted(updateMatches);
 </script>
 <template>
-  <div class="flex flex-col h-full border border-gray-700">
-    <div class="p-1 border-b border-gray-700">
-      <input v-model="searchTerm" class="w-full text-xs p-1" placeholder="Search..." />
+  <div class="flex flex-col h-full border border-gray-700 overflow-hidden">
+    <div ref="preRef" class="flex-1 overflow-auto text-xs font-mono p-2">
+      <div v-for="(line, i) in highlightedLines" :key="i" class="flex code-line">
+        <div class="w-10 pr-2 select-none text-right text-gray-500">{{ i + 1 }}</div>
+        <div class="whitespace-pre-wrap flex-1" v-html="line"></div>
+      </div>
     </div>
-    <pre ref="preRef" class="overflow-auto flex-1 text-xs font-mono p-2" v-html="match && match.response ? highlight(match.response) : ''"></pre>
+    <div class="p-1 border-t border-gray-700 flex items-center gap-1 text-xs">
+      <input v-model="searchTerm" class="p-1 flex-1" placeholder="Search..." />
+      <button class="p-1 border border-gray-700" @click="prevMatch">&lt;</button>
+      <button class="p-1 border border-gray-700" @click="nextMatch">&gt;</button>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.code-line {
+  display: flex;
+}
+</style>

--- a/packages/frontend/src/components/results/Results.vue
+++ b/packages/frontend/src/components/results/Results.vue
@@ -191,12 +191,12 @@ const selectRow = (row: GrepMatch) => {
               </VirtualScroller>
             </div>
           </SplitterPanel>
-          <SplitterPanel :size="60" :minSize="40">
+          <SplitterPanel :size="60" :minSize="40" class="overflow-hidden">
             <Splitter>
-              <SplitterPanel>
+              <SplitterPanel class="overflow-hidden">
                 <RequestViewer :match="store.selectedMatch" :pattern="store.pattern" />
               </SplitterPanel>
-              <SplitterPanel>
+              <SplitterPanel class="overflow-hidden">
                 <ResponseViewer :match="store.selectedMatch" :pattern="store.pattern" />
               </SplitterPanel>
             </Splitter>


### PR DESCRIPTION
## Summary
- keep request/response panels fixed and scrollable
- add line numbers and built‑in search to request/response viewers
- sync scrolling and highlight selected match lines

## Testing
- `pnpm -r typecheck` *(fails: Cannot find type definition file for '@caido/sdk-backend')*

------
https://chatgpt.com/codex/tasks/task_e_68665db60d808331abb0d17bdb837fed