### PR TITLE
Enable row selection to show request and response viewers

### DIFF
--- a/packages/frontend/src/components/results/Results.vue
+++ b/packages/frontend/src/components/results/Results.vue
@@ -65,8 +65,10 @@ const sortedResults = computed(() => {
 watch(
   () => sortedResults.value,
   (rows) => {
-    if (rows.length > 0) {
+    if (rows.length > 0 && !store.selectedMatch) {
       store.selectMatch(rows[0] as GrepMatch);
+    } else if (rows.length === 0) {
+      store.selectMatch(null);
     }
   },
   { immediate: true }
@@ -125,7 +127,11 @@ const stopSearch = async () => {
 };
 
 const selectRow = (row: GrepMatch) => {
-  store.selectMatch(row);
+  if (store.selectedMatch === row) {
+    store.selectMatch(null);
+  } else {
+    store.selectMatch(row);
+  }
 };
 
 const columnWidths = reactive({
@@ -206,7 +212,7 @@ const rowMinWidth = computed(() =>
           </div>
         </div>
         <Splitter layout="vertical" class="h-full">
-          <SplitterPanel :size="40" :minSize="20">
+          <SplitterPanel :size="store.selectedMatch ? 40 : 100" :minSize="20">
             <div class="border border-gray-700 h-full flex flex-col overflow-hidden">
               <div
                 class="flex bg-zinc-800 text-xs font-semibold border-b border-gray-700 sticky top-0 z-10"
@@ -320,13 +326,24 @@ const rowMinWidth = computed(() =>
               </div>
             </div>
           </SplitterPanel>
-          <SplitterPanel :size="60" :minSize="40" class="overflow-hidden">
+          <SplitterPanel
+            v-if="store.selectedMatch"
+            :size="60"
+            :minSize="40"
+            class="overflow-hidden"
+          >
             <div class="flex h-full">
               <div class="flex-1 overflow-auto">
-                <RequestViewer :match="store.selectedMatch" :pattern="store.pattern" />
+                <RequestViewer
+                  :match="store.selectedMatch"
+                  :pattern="store.pattern"
+                />
               </div>
               <div class="flex-1 overflow-auto">
-                <ResponseViewer :match="store.selectedMatch" :pattern="store.pattern" />
+                <ResponseViewer
+                  :match="store.selectedMatch"
+                  :pattern="store.pattern"
+                />
               </div>
             </div>
           </SplitterPanel>

--- a/packages/frontend/src/stores/grepStore.ts
+++ b/packages/frontend/src/stores/grepStore.ts
@@ -35,7 +35,7 @@ export const useGrepStore = defineStore("grep", () => {
   });
 
   const selectedMatch = ref<GrepMatch | null>(null);
-  const selectMatch = (match: GrepMatch) => {
+  const selectMatch = (match: GrepMatch | null) => {
     selectedMatch.value = match;
   };
 


### PR DESCRIPTION
## Summary
- allow selecting/deselecting rows in the results table
- auto-select the first row when results load
- only show the request/response viewers when a row is selected

## Testing
- `pnpm -r typecheck` *(fails: Cannot find type definition file for '@caido/sdk-backend')*

------
https://chatgpt.com/codex/tasks/task_e_68666badf2ac8331bb30d2c6234bf5aa