### PR TITLE
Fix unmatched HTML tag in Results.vue

### DIFF
--- a/packages/frontend/src/components/results/Results.vue
+++ b/packages/frontend/src/components/results/Results.vue
@@ -336,7 +336,6 @@ const rowMinWidth = computed(() =>
             </div>
           </div>
         </div>
-      </div>
-    </template>
+      </template>
   </Card>
 </template>


### PR DESCRIPTION
## Summary
- remove stray closing `div` from `Results.vue` template

## Testing
- `pnpm -r typecheck` *(fails: Cannot find type definition file for '@caido/sdk-backend')*

------
https://chatgpt.com/codex/tasks/task_e_6866700bafb883319839d124ed996fd8