### PR TITLE
Fix result selection and request preview

### DIFF
--- a/packages/backend/src/services/grep.ts
+++ b/packages/backend/src/services/grep.ts
@@ -306,6 +306,8 @@ export const grepService = {
   ): GrepMatch[] {
     const results: GrepMatch[] = [];
 
+    const id = Number(request.getId());
+
     const reqRaw = request.getRaw()?.toText() || "";
     const respRaw = response?.getRaw()?.toText() || "";
 
@@ -318,6 +320,7 @@ export const grepService = {
       const headerMatches = extractMatches(reqHeaders, regex, matchGroups);
       for (const m of headerMatches) {
         results.push({
+          id,
           url,
           match: m,
           location: "Request Header",
@@ -329,6 +332,7 @@ export const grepService = {
       const bodyMatches = extractMatches(reqBody, regex, matchGroups);
       for (const m of bodyMatches) {
         results.push({
+          id,
           url,
           match: m,
           location: "Request Body",
@@ -342,6 +346,7 @@ export const grepService = {
       const headerMatches = extractMatches(resHeaders, regex, matchGroups);
       for (const m of headerMatches) {
         results.push({
+          id,
           url,
           match: m,
           location: "Response Header",
@@ -353,6 +358,7 @@ export const grepService = {
       const bodyMatches = extractMatches(resBody, regex, matchGroups);
       for (const m of bodyMatches) {
         results.push({
+          id,
           url,
           match: m,
           location: "Response Body",

--- a/packages/shared/src/results.ts
+++ b/packages/shared/src/results.ts
@@ -15,6 +15,7 @@ export interface GrepStatus {
 }
 
 export interface GrepMatch {
+  id: number;
   url: string;
   match: string;
   location: string;


### PR DESCRIPTION
## Summary
- include request id in backend GrepMatch
- track selection using id
- highlight selected rows and open original request
- add request/response preview panels with splitter

## Testing
- `pnpm -r typecheck` *(fails: Cannot find type definition file for '@caido/sdk-backend')*

------
https://chatgpt.com/codex/tasks/task_e_68669a487e308331a2c9ca2ae5cffb24