### PR TITLE
Fix unclosed div in Results.vue

### DIFF
--- a/packages/frontend/src/components/results/Results.vue
+++ b/packages/frontend/src/components/results/Results.vue
@@ -349,6 +349,7 @@ const rowMinWidth = computed(() =>
                   </template>
               </VirtualScroller>
             </div>
+          </div>
           </SplitterPanel>
           <SplitterPanel :size="30" :minSize="20">
             <TabView class="h-full">


### PR DESCRIPTION
## Summary
- close missing `div` in results table

## Testing
- `pnpm build` *(fails: caido-dev not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669bf2e078833190ba97b1384a9af7