### PR TITLE
Fix open request error message

### DIFF
--- a/packages/frontend/src/components/results/Results.vue
+++ b/packages/frontend/src/components/results/Results.vue
@@ -138,8 +138,8 @@ const openInCaido = async (row: GrepMatch) => {
   try {
     await sdk.window.openRequest(row.id);
   } catch (error) {
-    console.error('Failed to open request', error);
-    sdk.window.showToast('Failed to open request', { variant: 'error' });
+    console.error('Failed to open the request', error);
+    sdk.window.showToast('Failed to open the request', { variant: 'error' });
   }
 };
 


### PR DESCRIPTION
## Summary
- update text shown when failing to open a request

## Testing
- `pnpm -r typecheck` *(fails: Cannot find type definition file for '@caido/sdk-backend')*

------
https://chatgpt.com/codex/tasks/task_e_68669ec03ca483318bb126f2a7dd8e56